### PR TITLE
Fix UPDATE statement update_commands.md

### DIFF
--- a/data_modification_statements/update_commands.md
+++ b/data_modification_statements/update_commands.md
@@ -25,4 +25,4 @@ SET ratingDate = '2014'
 WHERE uID in (SELECT uID FROM Review WHERE ISNULL ratingDate) and ISNULL ratingDate;
 ```
 
-We added the `UPDATE` statement, and we're telling SQL to `UPDATE` the `Review` table. Find all the users with a `uID` that satisfy the subquery in the `WHERE` clause, but only consider reviews that currently have no `ratingDate`. Then take the `ratingDate` for those users and give it a value of `'2014'`. We'll assume we don't know the exact date that they rated the movie, but we know it was in 2014.
+We added the `UPDATE` statement, and we're telling SQL to `UPDATE` the `Review` table. Find all the users with a `uID` that satisfy the subquery in the `WHERE` clause, but only consider reviews that currently have no `ratingDate`. Then take the `ratingDate` for those reviews and give it a value of `'2014'`. We'll assume we don't know the exact date that they rated the movie, but we know it was in 2014.

--- a/data_modification_statements/update_commands.md
+++ b/data_modification_statements/update_commands.md
@@ -22,7 +22,7 @@ Well no we want to update the `ratingDate` for these two individuals in the `Rev
 ```sql
 UPDATE Review
 SET ratingDate = '2014'
-WHERE uID in (SELECT uID FROM Review WHERE ISNULL ratingDate);
+WHERE uID in (SELECT uID FROM Review WHERE ISNULL ratingDate) and ISNULL ratingDate;
 ```
 
-We added the `UPDATE` statement, and we're telling SQL to `UPDATE` the `Review` table. Find all the users with a `uID` that satisfy the subquery in the `WHERE` clause, and then take the `ratingDate` for those users and give it a value of `'2014'`. We'll assume we don't know the exact date that they rated the movie, but we know it was in 2014.
+We added the `UPDATE` statement, and we're telling SQL to `UPDATE` the `Review` table. Find all the users with a `uID` that satisfy the subquery in the `WHERE` clause, but only consider reviews that currently have no `ratingDate`. Then take the `ratingDate` for those users and give it a value of `'2014'`. We'll assume we don't know the exact date that they rated the movie, but we know it was in 2014.


### PR DESCRIPTION
Fixes code to exclude the value of ratingDate for reviews by uID 207 on 2014-03-07 and 2014-03-26 from being updated. It also updates the phrasing of the last paragraph to reflect code changes.

The previous statement updated all reviews by the uIDs, even if they already had a date assigned. According to the example database in the introduction that would include all reviews by users, even if there was already a ratingDate.
