### PR TITLE
Fix typos in basic select statements README file

### DIFF
--- a/basic_select_statements/README.md
+++ b/basic_select_statements/README.md
@@ -54,7 +54,7 @@ The resulting movies would include: *Gravity*, *Harry Potter*, *Cast Away*, and 
 
 ### Combing Two Relations:
 
-Now let’s create a query that combines two relations, such as finding movie titles, mID's and the rating that the movie recieved. We’re now involving the `Movie` table, and the `Review` table.
+Now let’s create a query that combines two relations, such as finding movie titles, mID's and the rating that the movie received. We’re now involving the `Movie` table, and the `Review` table.
 
 Combining relations looks like this:
 
@@ -81,7 +81,7 @@ WHERE Movie.mID = Review.mID
     and Rating > 2 and Year < 2000;
 ```
 
-So in this case, we are looking for `mID`, `Title`, and `Rating`. We are looking inside the `Movie` and `Review` tables, and we have a join condition making sure that the query knows the `mID` in the `Movie` table is the same `mID` in the `Review` table. We are filtering the results based on the year the movie was created, and the rating it recieved. We would then get a table with the results of the query. The results would include all movies that were created before the year 2000, with a rating greater than 2.
+So in this case, we are looking for `mID`, `Title`, and `Rating`. We are looking inside the `Movie` and `Review` tables, and we have a join condition making sure that the query knows the `mID` in the `Movie` table is the same `mID` in the `Review` table. We are filtering the results based on the year the movie was created, and the rating it received. We would then get a table with the results of the query. The results would include all movies that were created before the year 2000, with a rating greater than 2.
 
 The resulting movies would be: *Top Gun*, *Titanic*, *The Lion King*, and *The Godfather*.
 


### PR DESCRIPTION
This fixes the spelling typo of "recieved" to "received".